### PR TITLE
Add zoom recording mock

### DIFF
--- a/backend/controllers/webhook.js
+++ b/backend/controllers/webhook.js
@@ -13,9 +13,8 @@ router.post('/', (req, res) => {
   const { event } = req.body;
 
   if (process.env.NODE_ENV === 'development') {
-    console.log(process.env.ZOOM_WEBHOOK_SECRET_TOKEN);
     console.log('headers:', req.headers);
-    console.log('body:', req.body);
+    console.log('body:', JSON.stringify(req.body, null, 2));
   }
 
   switch (event) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,5 +1,6 @@
 import app from './app.js';
 import { sequelize } from './models/index.js';
+import zoomMockServer from './mock/zoom/index.js';
 
 const port = process.env.PORT;
 
@@ -13,3 +14,9 @@ sequelize
   .catch((err) => {
     console.log('error starting server:', err);
   });
+
+if (process.env.NODE_ENV === 'development') {
+  zoomMockServer.listen(8081, () => {
+    console.log('Zoom mock server starting on port: ' + 8081);
+  });
+}

--- a/backend/mock/zoom/controllers/index.js
+++ b/backend/mock/zoom/controllers/index.js
@@ -1,0 +1,8 @@
+import recordingController from './recording.js';
+import { Router } from 'express';
+
+const router = Router();
+
+router.use('/recording', recordingController);
+
+export default router;

--- a/backend/mock/zoom/controllers/recording.js
+++ b/backend/mock/zoom/controllers/recording.js
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import fs from 'node:fs';
+import { zoomRecordingPath } from '../path/index.js';
+
+const router = new Router();
+
+const checkDownloadToken = (req, res, next) => {
+  const authHeader = req.get('authorization');
+
+  if (!authHeader || authHeader === '') {
+    return res.status(401).json({ message: 'missing or invalid token' });
+  }
+
+  next();
+};
+
+router.get('/download/:fileId', checkDownloadToken, (req, res) => {
+  const id = req.params.fileId;
+  if (!id) {
+    return res.status(400).json({ message: 'invalid file id' });
+  }
+
+  const fileName = Buffer.from(id, 'base64').toString('utf-8');
+
+  const path = `${zoomRecordingPath}/${fileName}`;
+
+  if (!fs.existsSync(path)) {
+    return res.status(400).json({ message: 'file does not exist' });
+  }
+
+  res.download(path);
+});
+
+export default router;

--- a/backend/mock/zoom/index.js
+++ b/backend/mock/zoom/index.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import appRouter from './controllers/index.js';
+import { fileWatcher } from './path/watcher.js';
+
+const app = express();
+
+app.use(express.json());
+
+app.get('/healthcheck', (req, res) => {
+  res.status(200).json({ message: 'ok' });
+});
+
+app.use('/', appRouter);
+
+fileWatcher();
+
+export default app;

--- a/backend/mock/zoom/path/index.js
+++ b/backend/mock/zoom/path/index.js
@@ -1,5 +1,6 @@
 import os from 'os';
 import path from 'node:path';
+import fs from 'node:fs';
 
 const currentUser = os.userInfo().username;
 let zoomRecordingPath = path.join('/Users', currentUser, 'Documents', 'Zoom');
@@ -15,5 +16,9 @@ if (os.platform() === 'win32') {
 }
 
 zoomRecordingPath = path.resolve(zoomRecordingPath);
+
+if (!fs.existsSync(zoomRecordingPath)) {
+  fs.mkdirSync(zoomRecordingPath, { recursive: true });
+}
 
 export { zoomRecordingPath };

--- a/backend/mock/zoom/path/index.js
+++ b/backend/mock/zoom/path/index.js
@@ -18,6 +18,7 @@ if (os.platform() === 'win32') {
 zoomRecordingPath = path.resolve(zoomRecordingPath);
 
 if (!fs.existsSync(zoomRecordingPath)) {
+  console.warn(`${zoomRecordingPath} was not found. Attempting to create it.`);
   fs.mkdirSync(zoomRecordingPath, { recursive: true });
 }
 

--- a/backend/mock/zoom/path/index.js
+++ b/backend/mock/zoom/path/index.js
@@ -1,0 +1,19 @@
+import os from 'os';
+import path from 'node:path';
+
+const currentUser = os.userInfo().username;
+let zoomRecordingPath = path.join('/Users', currentUser, 'Documents', 'Zoom');
+
+if (os.platform() === 'win32') {
+  zoomRecordingPath = path.join(
+    'C:',
+    'Users',
+    currentUser,
+    'Documents',
+    'Zoom'
+  );
+}
+
+zoomRecordingPath = path.resolve(zoomRecordingPath);
+
+export { zoomRecordingPath };

--- a/backend/mock/zoom/path/watcher.js
+++ b/backend/mock/zoom/path/watcher.js
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import { zoomRecordingPath } from './index.js';
+import { setTimeout } from 'node:timers/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export const fileWatcher = async () => {
+  const watcher = await fs.watch(zoomRecordingPath);
+  console.log(`starting file watcher on ${zoomRecordingPath}`);
+
+  for await (const event of watcher) {
+    const { filename, eventType } = event;
+    if (!filename || filename === '.DS_Store') {
+      continue;
+    }
+
+    console.log(`event type: ${eventType}`);
+
+    const dir = path.resolve(zoomRecordingPath, filename);
+
+    console.log(`watching the path ${dir}`);
+    watchDir(dir);
+  }
+};
+
+const watchDir = async (dir) => {
+  let audioFile = '';
+  let videoFile = '';
+  const parent = path.basename(dir);
+
+  while (!audioFile || !videoFile) {
+    const files = await fs.readdir(dir);
+
+    if (!videoFile) {
+      const mp4 = files.find((f) => f.endsWith('.mp4'));
+      if (mp4) {
+        videoFile = path.join(parent, mp4);
+      }
+    }
+
+    if (!audioFile) {
+      const m4a = files.find((f) => f.endsWith('.m4a'));
+      if (m4a) {
+        audioFile = path.join(parent, m4a);
+      }
+    }
+
+    await setTimeout(1000);
+  }
+
+  sendWebHook(audioFile, videoFile);
+};
+
+const sendWebHook = (...filePaths) => {
+  const fileObject = (filePath) => {
+    const pathFileHash = Buffer.from(filePath).toString('base64');
+    const fileExt = path.extname(filePath);
+
+    return {
+      id: randomUUID(),
+      meeting_id: randomUUID(),
+      recording_start: Date.now(),
+      recording_end: Date.now(),
+      recording_type:
+        fileExt === '.m4a' ? 'audio_only' : 'shared_screen_with_speaker_view',
+      file_type: fileExt === '.m4a' ? 'M4A' : 'MP4',
+      file_size: 0,
+      file_extension: fileExt === '.m4a' ? 'M4A' : 'MP4',
+      play_url: `http://localhost:8081/recording/play/${pathFileHash}`,
+      download_url: `http://localhost:8081/recording/download/${pathFileHash}`,
+      status: 'completed',
+    };
+  };
+
+  const recording_files = filePaths.map((filePath) => fileObject(filePath));
+
+  const request = {
+    event: 'recording.completed',
+    event_ts: Date.now(),
+    payload: {
+      account_id: randomUUID(),
+      object: {
+        id: 0,
+        uuid: randomUUID(),
+        host_id: randomUUID(),
+        topic: path.dirname(filePaths[0]),
+        type: 4,
+        start_time: Date.now(),
+        host_email: 'mocked@email.com',
+        recording_files,
+      },
+    },
+  };
+
+  fetch('http://localhost:8080/api/webhook', {
+    method: 'POST',
+    body: JSON.stringify(request),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => {
+    if (!res.ok) {
+      console.error('received error status code:', res.status);
+    }
+  });
+};

--- a/backend/mock/zoom/path/watcher.js
+++ b/backend/mock/zoom/path/watcher.js
@@ -10,11 +10,14 @@ export const fileWatcher = async () => {
 
   for await (const event of watcher) {
     const { filename, eventType } = event;
-    if (!filename || filename === '.DS_Store') {
+    console.log(`event type: ${eventType}`);
+    if (eventType !== 'rename') {
       continue;
     }
 
-    console.log(`event type: ${eventType}`);
+    if (!filename || filename === '.DS_Store') {
+      continue;
+    }
 
     const dir = path.resolve(zoomRecordingPath, filename);
 

--- a/backend/mock/zoom/path/watcher.js
+++ b/backend/mock/zoom/path/watcher.js
@@ -10,7 +10,6 @@ export const fileWatcher = async () => {
 
   for await (const event of watcher) {
     const { filename, eventType } = event;
-    console.log(`event type: ${eventType}`);
     if (eventType !== 'rename') {
       continue;
     }


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

<!-- Please do not leave this blank -->

This PR adds a mock for cloud zoom recordings. This is because cloud recordings are a paid Zoom account feature, so this is useful as a temporary work around until we get a paid account to test with.

I tried to make this match with what is in the Zoom webhook documentation, however, not all features are implemented. You will only be able to download the files with this mock

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [ ] 📜 contributing.md
- [ ] 📓 docs
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed
